### PR TITLE
Update readme's initial example to explain how to get the driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage of I2CDevice class directly:
 
 ```
 require "i2c"
-
+require "i2c/driver/i2c-dev"
 device = I2CDevice.new(address: 0x60, driver: I2CDevice::Driver::I2CDev.new("/dev/i2c-1"))
 
 # like i2c-tools's i2cget command


### PR DESCRIPTION
The first example doesn't work until you realize you need to require the driver file. This makes it more explicit. 